### PR TITLE
Ignore explicit implementations of properties

### DIFF
--- a/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
@@ -226,6 +226,26 @@ namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
         }
 
         [Test]
+        public void AnalyzeWhenReadOnlyFieldSetInConstructorIsNotDisposed()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        private readonly object? ↓field;
+
+        public TestClass() => field = new DummyDisposable();
+
+        [TearDown]
+        public void TearDownMethod()
+        {{
+            Assert.That(field, Is.Not.Null);
+        }}
+
+        {DummyDisposable}
+        ");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
         public void FieldConditionallyAssignedInCalledLocalMethod()
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
@@ -528,7 +548,25 @@ namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
         }
 
         [Test]
-        public void AnalyzeWhenPropertydSetInConstructorIsNotDisposed()
+        public void AnalyzeWhenReadOnlyPropertyWithInitializerIsNotDisposed()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        ↓protected object? Property {{ get; }} = new DummyDisposable();
+
+        [TearDown]
+        public void TearDownMethod()
+        {{
+            Assert.That(Property, Is.Not.Null);
+        }}
+
+        {DummyDisposable}
+        ");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenPropertySetInConstructorIsNotDisposed()
         {
             var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
         ↓protected object? Property {{ get; private set; }}
@@ -539,6 +577,26 @@ namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
         public void TearDownMethod()
         {{
             Property = null;
+        }}
+
+        {DummyDisposable}
+        ");
+
+            RoslynAssert.Diagnostics(analyzer, expectedDiagnostic, testCode);
+        }
+
+        [Test]
+        public void AnalyzeWhenReadOnlyPropertySetInConstructorIsNotDisposed()
+        {
+            var testCode = TestUtility.WrapMethodInClassNamespaceAndAddUsings($@"
+        ↓protected object? Property {{ get; }}
+
+        public TestClass() => Property = new DummyDisposable();
+
+        [TearDown]
+        public void TearDownMethod()
+        {{
+            Assert.That(Property, Is.Not.Null);
         }}
 
         {DummyDisposable}

--- a/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
+++ b/src/nunit.analyzers.tests/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzerTests.cs
@@ -955,5 +955,43 @@ namespace NUnit.Analyzers.Tests.DisposeFieldsInTearDown
 
             RoslynAssert.Valid(analyzer, testCodePart1, testCodePart2);
         }
+
+        [Test]
+        public void DoesNotThrowExceptionsWhenUsingAbstractClasses()
+        {
+            var testCode = TestUtility.WrapClassInNamespaceAndAddUsing(@"
+        [TestFixture]
+        public abstract class Test : IDataProvider
+        {
+            private DataReader DataReader;
+
+            DataReader IDataProvider.DataReader
+            {
+                get => DataReader;
+                set => DataReader = value;
+            }
+
+            protected Test() => DataReader = new DataReader(this);
+
+            [OneTimeSetUp]
+            public void SetListener() => throw new NotImplementedException();
+        }
+
+        public interface IDataProvider
+        {
+            DataReader DataReader
+            {
+                get;
+                set;
+            }
+        }
+
+        public sealed class DataReader
+        {
+            public DataReader(IDataProvider provider) => throw new NotImplementedException();
+        }");
+
+            RoslynAssert.Valid(analyzer, testCode);
+        }
     }
 }

--- a/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs
+++ b/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs
@@ -113,6 +113,9 @@ namespace NUnit.Analyzers.DisposeFieldsInTearDown
 
             foreach (var property in propertyDeclarations)
             {
+                if (property.ExplicitInterfaceSpecifier is not null)
+                    continue;
+
                 if (property.Initializer is not null)
                 {
                     if (NeedsDisposal(model, property.Initializer.Value))

--- a/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs
+++ b/src/nunit.analyzers/DisposeFieldsAndPropertiesInTearDown/DisposeFieldsAndPropertiesInTearDownAnalyzer.cs
@@ -85,6 +85,10 @@ namespace NUnit.Analyzers.DisposeFieldsInTearDown
                                                        .OfType<PropertyDeclarationSyntax>()
                                                        .Where(x => x.AccessorList is not null);
 
+            bool hasConstructors = classDeclaration.Members
+                                                   .OfType<ConstructorDeclarationSyntax>()
+                                                   .Any();
+
             HashSet<string> symbolsWithDisposableInitializers = new();
 
             Dictionary<string, SyntaxNode> symbols = new();
@@ -98,13 +102,11 @@ namespace NUnit.Analyzers.DisposeFieldsInTearDown
                         {
                             symbolsWithDisposableInitializers.Add(field.Identifier.Text);
                             symbols.Add(field.Identifier.Text, field);
-                        }
-                        else if (CanBeAssignedTo(fieldDeclaration))
-                        {
-                            symbols.Add(field.Identifier.Text, field);
+                            continue;
                         }
                     }
-                    else
+
+                    if (CanBeAssignedTo(fieldDeclaration, hasConstructors))
                     {
                         symbols.Add(field.Identifier.Text, field);
                     }
@@ -121,10 +123,12 @@ namespace NUnit.Analyzers.DisposeFieldsInTearDown
                     if (NeedsDisposal(model, property.Initializer.Value))
                     {
                         symbolsWithDisposableInitializers.Add(property.Identifier.Text);
+                        symbols.Add(property.Identifier.Text, property);
+                        continue;
                     }
                 }
 
-                if (CanBeAssignedTo(property))
+                if (CanBeAssignedTo(property, hasConstructors))
                 {
                     symbols.Add(property.Identifier.Text, property);
                 }
@@ -177,16 +181,19 @@ namespace NUnit.Analyzers.DisposeFieldsInTearDown
                 NUnitFrameworkConstants.NameOfTearDownAttribute, otherMethods, tearDownMethods);
         }
 
-        private static bool CanBeAssignedTo(FieldDeclarationSyntax declaration)
+        private static bool CanBeAssignedTo(FieldDeclarationSyntax declaration, bool hasConstructors)
         {
-            return !declaration.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.ConstKeyword) || modifier.IsKind(SyntaxKind.ReadOnlyKeyword));
+            return !declaration.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.ConstKeyword)) &&
+                (!declaration.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.ReadOnlyKeyword)) || hasConstructors);
         }
 
-        private static bool CanBeAssignedTo(PropertyDeclarationSyntax declaration)
+        private static bool CanBeAssignedTo(PropertyDeclarationSyntax declaration, bool hasConstructors)
         {
             AccessorListSyntax? accessorList = declaration.AccessorList;
-            return accessorList is not null &&
-                accessorList.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.SetAccessorDeclaration));
+            if (accessorList is null)
+                return false;           // Expression body property
+
+            return hasConstructors || accessorList.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.SetAccessorDeclaration));
         }
 
         private static bool HasAttribute(IMethodSymbol method, string attributeName)


### PR DESCRIPTION
Fixes #659

This to cope with cases where a field and an explicit property have the same name.

